### PR TITLE
Replace hub with gh

### DIFF
--- a/.github/workflows/check-for-new-master-data.yaml
+++ b/.github/workflows/check-for-new-master-data.yaml
@@ -18,3 +18,5 @@ jobs:
         run: |
           chmod +x ./scripts/check-for-new-master-data.sh
           ./scripts/check-for-new-master-data.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/check-for-new-master-data.sh
+++ b/scripts/check-for-new-master-data.sh
@@ -29,7 +29,7 @@ if [ ! -f "raw-master-data/s/$file_name" ]; then
   git add .
   git commit -m "Add new master data for $date"
   git push origin "new-master-data-${date}"
-  gh pr create -m "Add new master data for ${date}" -B master -H "new-master-data-${date}"
+  gh pr create --title "Add new master data for ${date}" --body "This PR was created automatically by GitHub Actions" -B master -H "new-master-data-${date}"
 else
   echo "No new master data available."
 fi

--- a/scripts/check-for-new-master-data.sh
+++ b/scripts/check-for-new-master-data.sh
@@ -29,7 +29,7 @@ if [ ! -f "raw-master-data/s/$file_name" ]; then
   git add .
   git commit -m "Add new master data for $date"
   git push origin "new-master-data-${date}"
-  gh pr create --title "Add new master data for ${date}" --body "This PR was created automatically by GitHub Actions" -B master -H "new-master-data-${date}"
+  gh pr create --title "Add new master data for ${date}" --body "This PR was created automatically by GitHub Actions" -B main -H "new-master-data-${date}"
 else
   echo "No new master data available."
 fi

--- a/scripts/check-for-new-master-data.sh
+++ b/scripts/check-for-new-master-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Exit if pull request already exists
-if [ -n "$(hub pr list -h new-master-data-*)" ]; then
+if [ -n "$(gh pr list -H new-master-data-* --state open)" ]; then
   echo "Pull request already exists."
   exit 0
 fi
@@ -29,7 +29,7 @@ if [ ! -f "raw-master-data/s/$file_name" ]; then
   git add .
   git commit -m "Add new master data for $date"
   git push origin "new-master-data-${date}"
-  hub pull-request -m "Add new master data for ${date}" -b master -h "new-master-data-${date}"
+  gh pr create -m "Add new master data for ${date}" -B master -H "new-master-data-${date}"
 else
   echo "No new master data available."
 fi

--- a/scripts/check-for-new-master-data.sh
+++ b/scripts/check-for-new-master-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Exit if pull request already exists
-if [ -n "$(gh pr list -H new-master-data-* --state open)" ]; then
+if [ -n "$(gh pr list --search head:new-master-data --state open)" ]; then
   echo "Pull request already exists."
   exit 0
 fi


### PR DESCRIPTION
[マスターのアップデートが失敗している](https://github.com/kohii/medi-xplorer/actions/runs/7270809639)。 https://github.com/mislav/hub/issues/3338 によれば `hub` コマンドはすでにGitHub Actions Hosted Runnerに含まれていないとのこと。公式CLIを使うことで問題を解決する。

https://github.com/KengoTODA/medi-xplorer/actions/runs/7282612841/job/19845250481 と https://github.com/KengoTODA/medi-xplorer/actions/runs/7282666037/job/19845390436#step:3:8 で動作確認済み。