### PR TITLE
利用規約ページを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ next-env.d.ts
 # generated master data
 /public/master-data/s/*
 shinryoukoui-master-versions.json
+
+# claude
+.claude/settings.local.json
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MediXplorer is a Next.js application for searching and browsing Japanese medical procedure master data (医科診療行為マスター) provided by the Social Insurance Medical Fee Payment Fund. The app is built with TypeScript, React, and deployed on Cloudflare Pages.
+
+## Common Development Commands
+
+```bash
+# Development
+npm install              # Install dependencies
+npm run build:masters    # Generate master data (required before first run)
+npm run dev             # Start development server
+
+# Build & Deploy
+npm run build           # Build for production
+npm run pages:build     # Build for Cloudflare Pages
+npm run pages:deploy    # Deploy to Cloudflare Pages
+
+# Code Quality
+npm run lint            # Run ESLint
+npm run lint:fix        # Run ESLint with auto-fix
+npm test                # Run all tests
+npm run test:watch      # Run tests in watch mode
+
+# Data Generation
+npm run generate-master-data      # Convert CSV to TSV format
+npm run generate-master-versions  # Generate version list from raw data
+```
+
+## Architecture Overview
+
+### Data Flow
+1. Raw CSV files in Shift_JIS encoding are stored in `raw-master-data/s/`
+2. `generate-master-data.ts` converts them to UTF-8 TSV files in `public/master-data/s/`
+3. The app loads TSV data on-demand based on version selection
+4. Data is cached using React Query for performance
+
+### Key Architectural Patterns
+
+- **Next.js App Router**: Uses the app directory structure with server/client components
+- **State Management**: React Context for global state (master data, shisetsukijun data)
+- **Data Fetching**: React Query for async state management and caching
+- **Styling**: Tailwind CSS v4 with PostCSS
+- **Path Aliases**: `@/` maps to `src/` directory
+
+### Core Components Structure
+
+- `src/app/`: Next.js app router pages and layouts
+- `src/components/`: Reusable UI components (buttons, modals, tables, etc.)
+- `src/features/`: Domain-specific features
+  - `advanced-search/`: Complex search functionality
+  - `display-fields/`: Configurable field display
+  - `exports/`: Data export functionality
+  - `search/`: Search parsing and filtering logic
+  - `shinryoukoui-master-fields/`: Master data field definitions
+- `src/contexts/`: React contexts for global state
+- `src/hooks/`: Custom React hooks
+- `src/apis/`: Data fetching functions
+
+### Important Code Conventions
+
+- **ESLint Rules**: 
+  - Semicolons required
+  - 2-space indentation
+  - Double quotes for strings
+  - Strict import ordering (builtin → external → internal)
+- **TypeScript**: Strict mode enabled
+- **File Naming**: kebab-case for files, PascalCase for components
+- **Exports**: Named exports preferred over default exports
+
+### Master Data Versions
+
+The app supports multiple versions of master data. Version management is handled through:
+- `shinryoukoui-master-versions.json`: Auto-generated list of available versions
+- Layout versions in `layouts.ts` define field structure changes over time
+- Version selection persists via URL search params
+
+### Testing
+
+Tests use Jest with ts-jest for TypeScript support. Test files follow the pattern `*.test.ts`.
+
+```bash
+npm test                    # Run all tests
+npm run test:watch         # Run tests in watch mode
+```

--- a/setup-project.sh
+++ b/setup-project.sh
@@ -1,0 +1,2 @@
+npm install
+npm run build:masters

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Suspense } from "react";
 
 import { AppIcon } from "@/components/app-icon";
@@ -27,6 +28,9 @@ export default function Home() {
       <footer>
         <div className="flex items-center justify-center h-24 gap-4 text-gray-500 text-sm">
           <div>© {new Date().getFullYear()} kohii</div>
+          <Link href="/terms" className="text-gray-500 text-sm underline">
+            利用規約
+          </Link>
           <a
             href="https://github.com/kohii/medi-xplorer"
             target="_blank"

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "利用規約 | MediXplorer",
+  description: "MediXplorerの利用規約",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <h1 className="text-3xl font-bold mb-8">利用規約</h1>
+      
+      <div className="prose max-w-none space-y-6">
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第1条（適用）</h2>
+          <p className="mb-4">
+            本利用規約（以下「本規約」）は、MediXplorer（以下「本サービス」）の利用条件を定めるものです。
+            本サービスを利用される全ての方（以下「利用者」）は、本規約に同意したものとみなします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第2条（サービス内容）</h2>
+          <p className="mb-4">
+            本サービスは、社会保険診療報酬支払基金が公開している医科診療行為マスターのデータを検索・閲覧できるようにした個人開発のツールです。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第3条（免責事項）</h2>
+          <p className="mb-4">
+            1. 本サービスで提供される情報の正確性、完全性、最新性について一切保証いたしません。
+          </p>
+          <p className="mb-4">
+            2. 本サービスの利用によって生じたいかなる損害についても、開発者は一切の責任を負いません。
+          </p>
+          <p className="mb-4">
+            3. 本サービスは「現状のまま」で提供され、明示的または黙示的な保証は一切行いません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第4条（利用者の責任）</h2>
+          <p className="mb-4">
+            1. 本サービスの利用は、利用者自身の責任において行ってください。
+          </p>
+          <p className="mb-4">
+            2. 実際の診療報酬請求等の業務で使用される場合は、必ず公式の資料をご確認ください。
+          </p>
+          <p className="mb-4">
+            3. 本サービスから得られた情報を元に行った判断・行動については、利用者が全ての責任を負うものとします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第5条（サービスの変更・中止）</h2>
+          <p className="mb-4">
+            本サービスは予告なく内容の変更、一時的な中断、または終了する場合があります。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第6条（本規約の変更）</h2>
+          <p className="mb-4">
+            本規約は予告なく変更される場合があります。変更後の規約は、本サービスに掲載した時点から効力を生じるものとします。
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
- 利用規約ページ (`/terms`) を作成しました
- トップページのフッターに利用規約へのリンクを追加しました
- 免責事項を含む6条構成の正式な利用規約として整備しました

## 変更内容
- `src/app/terms/page.tsx`: 新規作成 - 利用規約ページ
- `src/app/page.tsx`: フッターに利用規約リンクを追加

## テストプラン
- [ ] 利用規約ページ (`/terms`) が正しく表示されることを確認
- [ ] トップページのフッターから利用規約ページへのリンクが機能することを確認
- [ ] レスポンシブデザインが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)